### PR TITLE
Make passing the IOLoop to the constructor optional

### DIFF
--- a/lib/Future/Mojo.pm
+++ b/lib/Future/Mojo.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Carp 'croak';
 use Scalar::Util 'weaken';
+use Mojo::IOLoop;
 
 use parent 'Future';
 
@@ -14,13 +15,14 @@ sub new {
 	my $self = $proto->SUPER::new;
 	
 	$self->{loop} = ref $proto ? $proto->{loop} : shift;
+        $self->{loop} = Mojo::IOLoop->singleton if (not defined $self->{loop});
 	
 	return $self;
 }
 
 sub new_timer {
 	my $proto = shift;
-	my $self = $proto->new(shift);
+	my $self = __PACKAGE__->new();
 	my ($after) = @_;
 	
 	my $weakself = $self;

--- a/t/default_loop.t
+++ b/t/default_loop.t
@@ -6,24 +6,19 @@ BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 use Test::More;
 use Test::Identity;
 
-use Mojo::IOLoop;
 use Future::Mojo;
 
-my $loop = Mojo::IOLoop->new;
-
 {
-	my $future = Future::Mojo->new($loop);
+	my $future = Future::Mojo->new();
 	
-	identical $future->loop, $loop, '$future->loop yields $loop';
-	
-	$loop->next_tick(sub { $future->done('result') });
+	$future->loop->next_tick(sub { $future->done('result') });
 	
 	is_deeply [$future->get], ['result'], '$future->get on Future::Mojo';
 }
 
 # done_next_tick
 {
-	my $future = Future::Mojo->new($loop);
+	my $future = Future::Mojo->new();
 	
 	identical $future->done_next_tick('deferred result'), $future, '->done_next_tick returns $future';
 	ok !$future->is_ready, '$future not yet ready after ->done_next_tick';
@@ -33,7 +28,7 @@ my $loop = Mojo::IOLoop->new;
 
 # fail_next_tick
 {
-	my $future = Future::Mojo->new($loop);
+	my $future = Future::Mojo->new();
 	
 	identical $future->fail_next_tick("deferred exception\n"), $future, '->fail_next_tick returns $future';
 	ok !$future->is_ready, '$future not yet ready after ->fail_next_tick';
@@ -71,7 +66,7 @@ my $loop = Mojo::IOLoop->new;
 	Future::Mojo->new_timer(0.5)->on_done(sub { $future->done('safeguard') });
 	
 	my $errored;
-	my $done = Future::Mojo->new($loop)->done_next_tick('first_result')->on_done(sub {
+	my $done = Future::Mojo->new->done_next_tick('first_result')->on_done(sub {
 		eval { $future->await } or $errored = 1;
 	})->get;
 	

--- a/t/future.t
+++ b/t/future.t
@@ -9,7 +9,7 @@ use Test::Identity;
 use Mojo::IOLoop;
 use Future::Mojo;
 
-my $loop = Mojo::IOLoop->new;
+my $loop = Mojo::IOLoop->singleton;
 
 {
 	my $future = Future::Mojo->new($loop);


### PR DESCRIPTION
Hi!

I have the MojoX::IOLoop::Future module. It was a naive first impementation to get async things running (basically for testing the Paws module), but I saw your implementation, and it's a lot better!

I've been working adapting Paws to Future::Mojo, and been trying some stuff. My first PR is to not have to construct and pass a Mojo::IOLoop around, as Mojo::IOLoop has a singleton method that always returns the "global" IOLoop for the process, I thought it would be nice to make the $loop parameter optional.

I've made a new test file (copy of the original), and noticed that timer functions wanted the loop parameter too... I've eliminated the need for the loop parameter, as I think it makes the interface to Future::Mojo more "user-friendly".

BTW: initially I created Future::Mojo::IOLoop, or something like that, and the community asked me to change the namespace, so I took up MojoX::IOLoop::Future. If you want to occupy that namespace, that would be fine with me

Cheers,

Pplu