### PR TITLE
Allow use of the module when loop is running

### DIFF
--- a/lib/Future/Mojo.pm
+++ b/lib/Future/Mojo.pm
@@ -56,9 +56,7 @@ sub loop { shift->{loop} }
 
 sub await {
 	my $self = shift;
-	croak 'Awaiting a future while the event loop is running would recurse'
-		if $self->{loop}->is_running;
-	$self->{loop}->one_tick until $self->is_ready;
+	$self->{loop}->singleton->reactor->one_tick until $self->is_ready;
 }
 
 sub done_next_tick {

--- a/t/default_loop.t
+++ b/t/default_loop.t
@@ -60,18 +60,5 @@ use Future::Mojo;
 	ok !$called, '$future->cancel cancels a pending timer';
 }
 
-# loop recursion
-{
-	my $future = Future::Mojo->new_timer(0.1);
-	Future::Mojo->new_timer(0.5)->on_done(sub { $future->done('safeguard') });
-	
-	my $errored;
-	my $done = Future::Mojo->new->done_next_tick('first_result')->on_done(sub {
-		eval { $future->await } or $errored = 1;
-	})->get;
-	
-	is $done, 'first_result', 'first future completed';
-	ok $errored, '$future->await in a running event loop throws an error';
-}
 
 done_testing;

--- a/t/future.t
+++ b/t/future.t
@@ -74,18 +74,4 @@ my $loop = Mojo::IOLoop->new;
 	ok !$called, '$future->cancel cancels a pending timer';
 }
 
-# loop recursion
-{
-	my $future = Future::Mojo->new_timer($loop, 0.1);
-	Future::Mojo->new_timer($loop, 0.5)->on_done(sub { $future->done('safeguard') });
-	
-	my $errored;
-	my $done = Future::Mojo->new($loop)->done_next_tick('first_result')->on_done(sub {
-		eval { $future->await } or $errored = 1;
-	})->get;
-	
-	is $done, 'first_result', 'first future completed';
-	ok $errored, '$future->await in a running event loop throws an error';
-}
-
 done_testing;


### PR DESCRIPTION
I believe changing the call to `one_tick` to refer to the reactor singleton avoids the issue the `croak`  line was guarding against.