### PR TITLE
fix compatibility with Future::XS

### DIFF
--- a/lib/Future/Mojo.pm
+++ b/lib/Future/Mojo.pm
@@ -17,7 +17,8 @@ sub new {
 	my $proto = shift;
 	my $self = $proto->SUPER::new;
 	
-	$self->{loop} = ref $proto ? $proto->{loop} : (shift() // Mojo::IOLoop->singleton);
+	my $loop = ref $proto ? $proto->loop : (shift() // Mojo::IOLoop->singleton);
+	$self->set_udata(loop => $loop);
 	
 	return $self;
 }
@@ -55,13 +56,13 @@ sub _set_timer {
 	return $self;
 }
 
-sub loop { shift->{loop} }
+sub loop { shift->udata('loop') }
 
 sub await {
 	my $self = shift;
 	croak 'Awaiting a future while the event loop is running would recurse'
-		if $self->{loop}->is_running;
-	$self->{loop}->one_tick until $self->is_ready;
+		if $self->loop->is_running;
+	$self->loop->one_tick until $self->is_ready;
 }
 
 sub done_next_tick {

--- a/prereqs.yml
+++ b/prereqs.yml
@@ -2,7 +2,7 @@ runtime:
   requires:
     perl: '5.010001'
     Carp: 0
-    Future: '0.36'
+    Future: '0.49'
     Mojolicious: '7.54'
     parent: 0
     Role::Tiny: '2.000002'


### PR DESCRIPTION
With Future 0.49, Future objects may be implemented with Future::XS, which doesn't use blessed hashrefs for its objects. Instead, it provides the udata and set_udata methods for subclasses to store data.

Update the Future prereq to 0.49 to provide the udata/set_udata methods, and use them rather than storing directly in the object.